### PR TITLE
Support for Mobile Platforms (Solve Bug #2)

### DIFF
--- a/Assets/Editor/TileMap/TileMapBehaviourInspector.cs
+++ b/Assets/Editor/TileMap/TileMapBehaviourInspector.cs
@@ -34,6 +34,7 @@ public class TileMapBehaviourInspector : Editor
     private int m_tileResolution;
     private float m_tileSize;
     private MeshMode m_meshMode;
+    private TextureFormat m_textureFormat;
     private bool m_activeInEditMode;
 
     private Vector3 m_mouseHitPos = -Vector3.one;
@@ -55,6 +56,7 @@ public class TileMapBehaviourInspector : Editor
             m_tileResolution = meshSettings.TileResolution;
             m_tileSize = meshSettings.TileSize;
             m_meshMode = meshSettings.MeshMode;
+            m_textureFormat = meshSettings.TextureFormat;
         }
         m_activeInEditMode = m_tileMap.ActiveInEditMode;
     }
@@ -86,10 +88,11 @@ public class TileMapBehaviourInspector : Editor
                 new GUIContent("Tile Size", "The size of one tile in Unity units"),
                 m_tileSize);
             m_meshMode = (MeshMode)EditorGUILayout.EnumPopup("Mesh Mode", m_meshMode);
+            m_textureFormat = (TextureFormat)EditorGUILayout.EnumPopup("Texture Format", m_textureFormat);
 
             if (GUILayout.Button("Create/Recreate Mesh"))
             {
-                m_tileMap.MeshSettings = new TileMeshSettings(m_tilesX, m_tilesY, m_tileResolution, m_tileSize, m_meshMode);
+                m_tileMap.MeshSettings = new TileMeshSettings(m_tilesX, m_tilesY, m_tileResolution, m_tileSize, m_meshMode, m_textureFormat);
 
                 // if settings didnt change the mesh wouldnt be created, force creation
                 if (!m_tileMap.HasMesh)
@@ -255,7 +258,7 @@ public class TileMapBehaviourInspector : Editor
         if (!m_thumbnailCache.TryGetValue(sprite.name, out texture))
         {
             var rect = sprite.textureRect;
-            texture = new Texture2D((int)rect.width, (int)rect.height, TextureFormat.RGB24, false);
+            texture = new Texture2D((int)rect.width, (int)rect.height, m_textureFormat, false);
             texture.SetPixels(sprite.texture.GetPixels((int)rect.x, (int)rect.y, (int)rect.width, (int)rect.height));
             texture.Apply(false, true);
 

--- a/Assets/Plugins/TileMap/TileMeshSettings.cs
+++ b/Assets/Plugins/TileMap/TileMeshSettings.cs
@@ -30,6 +30,12 @@ namespace UnityTileMap
         [SerializeField]
         public float TileSize = 1f;
 
+        /// <summary>
+        /// The format of the texture built for the mesh.
+        /// </summary>
+        [SerializeField]
+        public TextureFormat TextureFormat = TextureFormat.RGBA32;
+
         [SerializeField]
         public MeshMode MeshMode = MeshMode.SingleQuad;
 
@@ -49,13 +55,18 @@ namespace UnityTileMap
         {
         }
 
-        public TileMeshSettings(int tilesX, int tilesY, int tileResolution, float tileSize, MeshMode meshMode)
+        public TileMeshSettings(int tilesX, int tilesY, int tileResolution, float tileSize, MeshMode meshMode) : this(tilesX, tilesY, tileResolution, tileSize, meshMode, TextureFormat.RGBA32)
+        {
+        }
+
+        public TileMeshSettings(int tilesX, int tilesY, int tileResolution, float tileSize, MeshMode meshMode, TextureFormat textureFormat)
         {
             TilesX = tilesX;
             TilesY = tilesY;
             TileResolution = tileResolution;
             TileSize = tileSize;
             MeshMode = meshMode;
+            TextureFormat = textureFormat;
         }
 
         public override bool Equals(object obj)
@@ -65,12 +76,16 @@ namespace UnityTileMap
             var o = obj as TileMeshSettings;
             if (o == null)
                 return false;
-            return TilesX == o.TilesX && TilesY == o.TilesY && TileResolution == o.TileResolution && TileSize == o.TileSize && MeshMode == o.MeshMode;
+            return TilesX == o.TilesX && TilesY == o.TilesY &&
+                   TileResolution == o.TileResolution && TileSize == o.TileSize &&
+                   MeshMode == o.MeshMode && TextureFormat == o.TextureFormat;
         }
 
         public override int GetHashCode()
         {
-            return TilesX.GetHashCode() ^ TilesY.GetHashCode() ^ TileResolution.GetHashCode() ^ TileSize.GetHashCode() ^ MeshMode.GetHashCode();
+            return TilesX.GetHashCode() ^ TilesY.GetHashCode() ^
+                   TileResolution.GetHashCode() ^ TileSize.GetHashCode() ^
+                   MeshMode.GetHashCode() ^ TextureFormat.GetHashCode();
         }
     }
 }

--- a/Assets/Plugins/TileMap/TileMeshSingleQuadBehaviour.cs
+++ b/Assets/Plugins/TileMap/TileMeshSingleQuadBehaviour.cs
@@ -132,7 +132,7 @@ namespace UnityTileMap
             m_texture = new Texture2D(
                 base.Settings.TilesX * base.Settings.TileResolution,
                 base.Settings.TilesY * base.Settings.TileResolution,
-                TextureFormat.RGBA32,
+                base.Settings.TextureFormat,
                 false);
             m_texture.name = "TileMapTexture";
 


### PR DESCRIPTION
Added a TextureFormat member to TileMeshSettings. Source textures must
be set to mobile-friendly formats (overridden per-platform in the
texture's import settings), and the TileMeshSettings TextureFormat
should also be mobile friendly when the build is set to those platforms.
