### PR TITLE
fix DrawGrid

### DIFF
--- a/Assets/Editor/TileMap/TileMapBehaviourInspector.cs
+++ b/Assets/Editor/TileMap/TileMapBehaviourInspector.cs
@@ -333,11 +333,11 @@ public class TileMapBehaviourInspector : Editor
 		Handles.color = Color.gray;
 		for (float i = 1; i < gridWidth; i++)
 		{
-			Handles.DrawLine(p + new Vector3(i, 0), new Vector3(i, gridHeight));
+			Handles.DrawLine(new Vector3(i, 0), new Vector3(i, gridHeight));
 		}
 		for (float i = 1; i < gridHeight; i++)
 		{
-			Handles.DrawLine(p + new Vector3(0, i), new Vector3(gridWidth, i));
+			Handles.DrawLine(new Vector3(0, i), new Vector3(gridWidth, i));
 		}
 		Handles.color = Color.white;
 		Handles.DrawLine(Vector3.zero, new Vector3(gridWidth, 0));


### PR DESCRIPTION
the grid was extending past the edge
for example Demo7: http://i.imgur.com/QdoOlzY.png
this also changes color & draws an edge
http://i.imgur.com/iHIkpCl.png

i guess maybe i make assumption that tileSize = unitSize =  PixelsPerMeter which it does but

this has nice selection and grid
http://wiki.unity3d.com/index.php/2D_Tilemap_Starter_Kit
