### PR TITLE
Polished, fixed a few bugs and added new features

### DIFF
--- a/Assets/Demo/Showcase 1 - Roguelike/LevelBehaviour.cs
+++ b/Assets/Demo/Showcase 1 - Roguelike/LevelBehaviour.cs
@@ -77,6 +77,14 @@ public class LevelBehaviour : MonoBehaviour
         var stairs = FindTile(TileType.StairsUp);
         var playerBehaviour = GameObject.Find("Player").GetComponent<PlayerBehaviour>();
         playerBehaviour.SetTilePosition((int)stairs.x, (int)stairs.y);
+        playerBehaviour.renderer.sortingOrder = 1;
+
+        TileMeshBehaviour mesh = m_tileMap.GetComponentInChildren<TileMeshBehaviour>();
+
+        if (mesh != null)
+        {
+            mesh.renderer.sortingOrder = 0;
+        }
     }
 
     public TileType GetTile(int x, int y)

--- a/Assets/Demo/Showcase 1 - Roguelike/PlayerBehaviour.cs
+++ b/Assets/Demo/Showcase 1 - Roguelike/PlayerBehaviour.cs
@@ -94,7 +94,7 @@ public class PlayerBehaviour : MonoBehaviour
         m_x = x;
         m_y = y;
         var tileBounds = m_tileMap.GetTileBoundsWorld(x, y);
-        transform.position = new Vector3(tileBounds.xMin, tileBounds.yMin, transform.position.z);
+        transform.position = new Vector3(tileBounds.xMin, tileBounds.yMin + 1, transform.position.z);
 
         // If we walk onto the stairs down...
         if (m_levelBehaviour.GetTile(m_x, m_y) == TileType.StairsDown)

--- a/Assets/Editor/TileMap/TileMapBehaviourInspector.cs
+++ b/Assets/Editor/TileMap/TileMapBehaviourInspector.cs
@@ -177,9 +177,9 @@ public class TileMapBehaviourInspector : Editor
 
                 int currentLayer = 0;
 
-                bool isLayerSet = mesh.renderer.sortingLayerName.Length >= 0;
+                bool isLayerSet = mesh.renderer.sortingLayerName.Length > 0;
 
-                if (isLayerSet)
+                if (! isLayerSet)
                 {
                     currentLayer = FindStringIndex(ref sortingLayers, "Default");
                 }
@@ -188,7 +188,7 @@ public class TileMapBehaviourInspector : Editor
                     currentLayer = FindStringIndex(ref sortingLayers, mesh.renderer.sortingLayerName);
                 }
 
-                int chosenLayer = EditorGUILayout.Popup("Sorting Layer Name", currentLayer, sortingLayers);
+                int chosenLayer = EditorGUILayout.Popup("Sorting Layer Name", Mathf.Max(currentLayer, 0), sortingLayers);
 
                 if (EditorGUI.EndChangeCheck() || ! isLayerSet)
                 {
@@ -270,18 +270,7 @@ public class TileMapBehaviourInspector : Editor
 
     private int FindStringIndex(ref string[] strings, string layer)
     {
-        int found = 0;
-
-        for (int i = 0; i < strings.Length; i++)
-        {
-            if (strings[i] == layer)
-            {
-                found = i;
-                break;
-            }
-        }
-
-        return found;
+        return Array.IndexOf(strings, layer);
     }
 
     private bool ShowTileDeletionWarning()

--- a/Assets/Editor/TileMap/TileMapBehaviourInspector.cs
+++ b/Assets/Editor/TileMap/TileMapBehaviourInspector.cs
@@ -177,18 +177,20 @@ public class TileMapBehaviourInspector : Editor
 
                 int currentLayer = 0;
 
-                for (int i = 0; i < sortingLayers.Length; i++)
+                bool isLayerSet = mesh.renderer.sortingLayerName.Length >= 0;
+
+                if (isLayerSet)
                 {
-                    if (sortingLayers[i] == mesh.renderer.sortingLayerName)
-                    {
-                        currentLayer = i;
-                        break;
-                    }
+                    currentLayer = FindStringIndex(ref sortingLayers, "Default");
+                }
+                else
+                {
+                    currentLayer = FindStringIndex(ref sortingLayers, mesh.renderer.sortingLayerName);
                 }
 
                 int chosenLayer = EditorGUILayout.Popup("Sorting Layer Name", currentLayer, sortingLayers);
 
-                if (EditorGUI.EndChangeCheck() || mesh.renderer.sortingLayerName.Length == 0)
+                if (EditorGUI.EndChangeCheck() || ! isLayerSet)
                 {
                     mesh.renderer.sortingLayerName = sortingLayers[chosenLayer];
                 }
@@ -264,6 +266,22 @@ public class TileMapBehaviourInspector : Editor
         }
 
         EditorUtility.SetDirty(this);
+    }
+
+    private int FindStringIndex(ref string[] strings, string layer)
+    {
+        int found = 0;
+
+        for (int i = 0; i < strings.Length; i++)
+        {
+            if (strings[i] == layer)
+            {
+                found = i;
+                break;
+            }
+        }
+
+        return found;
     }
 
     private bool ShowTileDeletionWarning()

--- a/Assets/Plugins/TileMap/Grid.cs
+++ b/Assets/Plugins/TileMap/Grid.cs
@@ -16,17 +16,58 @@ public class Grid<T> : IEnumerable<T>
     [SerializeField]
     private T[] m_data;
 
+    [SerializeField]
+    private T m_default;
+
     public void SetSize(int x, int y, T defaultValue)
     {
+        m_default = defaultValue;
+
         if (m_sizeX == x && m_sizeY == y)
             return;
         if (x < 1)
             throw new ArgumentException("Size x is less than 1");
         if (y < 1)
             throw new ArgumentException("Size y is less than 1");
+
+        T[] oldData = m_data;
+
+        m_data = Enumerable.Repeat(defaultValue, x * y).ToArray();
+
+        if (oldData != null)
+        {
+            for (int ix = 0; ix < Mathf.Min(m_sizeX, x); ix++)
+            {
+                for (int iy = 0; iy < Mathf.Min(m_sizeY, y); iy++)
+                {
+                    T oldValue = oldData[CoordToIndex(ix, iy)];
+
+                    m_data[(iy * x) + ix] = oldValue;
+                }
+            }
+        }
+
         m_sizeX = x;
         m_sizeY = y;
-        m_data = Enumerable.Repeat(defaultValue, x * y).ToArray();
+    }
+
+    public int Count
+    {
+        get
+        {
+            int count = 0;
+
+            for (int i = 0; i < m_data.Length; i++)
+            {
+                if (! m_data[i].Equals(m_default))
+                {
+                    count++;
+                }
+            }
+                
+
+            return count;
+        }
     }
 
     public void Clear()
@@ -34,7 +75,7 @@ public class Grid<T> : IEnumerable<T>
         if (m_data == null)
             return;
         for (int i = 0; i < m_data.Length; i++)
-            m_data[i] = default(T);
+            m_data[i] = m_default;
     }
 
     public int SizeX

--- a/Assets/Plugins/TileMap/TileMapBehaviour.cs
+++ b/Assets/Plugins/TileMap/TileMapBehaviour.cs
@@ -20,7 +20,7 @@ namespace UnityTileMap
         private TileSheet m_tileSheet;
 
         [SerializeField]
-        private bool m_activeInEditMode;
+        private bool m_activeInEditMode = true;
 
         private TileChunkManager m_chunkManager;
 
@@ -57,6 +57,15 @@ namespace UnityTileMap
             set
             {
                 ChunkManager.Settings = value;
+
+                if (m_tileMeshSettings != null)
+                {
+                    if (m_tileMeshSettings.TileResolution != value.TileResolution)
+                    {
+                        m_tileMapData.Clear();
+                    }
+                }
+
                 m_tileMeshSettings = value;
                 m_tileMapData.SetSize(m_tileMeshSettings.TilesX, m_tileMeshSettings.TilesY);
             }
@@ -65,6 +74,19 @@ namespace UnityTileMap
         public TileSheet TileSheet
         {
             get { return m_tileSheet; }
+        }
+
+        public int TileCount
+        {
+            get
+            {
+                return m_tileMapData.Count;
+            }
+        }
+
+        public void ClearTiles()
+        {
+            m_tileMapData.Clear();
         }
 
         private TileChunkManager ChunkManager

--- a/Assets/Plugins/TileMap/TileMeshSingleQuadBehaviour.cs
+++ b/Assets/Plugins/TileMap/TileMeshSingleQuadBehaviour.cs
@@ -22,8 +22,17 @@ namespace UnityTileMap
                     throw new ArgumentNullException("value");
                 if (base.Settings != null && base.Settings.Equals(value))
                     return;
+
+                bool resolutionChanged = false;
+
+                if (base.Settings != null)
+                {
+                    resolutionChanged = base.Settings.TileResolution != value.TileResolution;
+                }
+
                 base.Settings = value;
-                CreateTexture();
+
+                CreateTexture(! resolutionChanged);
             }
         }
 
@@ -127,16 +136,30 @@ namespace UnityTileMap
             return mesh;
         }
 
-        private void CreateTexture()
+        private void CreateTexture(bool keepData = true)
         {
-            m_texture = new Texture2D(
+            Texture2D texture = new Texture2D(
                 base.Settings.TilesX * base.Settings.TileResolution,
                 base.Settings.TilesY * base.Settings.TileResolution,
                 base.Settings.TextureFormat,
                 false);
-            m_texture.name = "TileMapTexture";
-            m_texture.filterMode = base.Settings.TextureFilterMode;
-            m_texture.wrapMode = TextureWrapMode.Clamp;
+            texture.name = "TileMapTexture";
+            texture.filterMode = base.Settings.TextureFilterMode;
+            texture.wrapMode = TextureWrapMode.Clamp;
+
+            if (m_texture && keepData)
+            {
+                int width = Mathf.Clamp(m_texture.width, 0, texture.width);
+                int height = Mathf.Clamp(m_texture.height, 0, texture.height);
+
+                Color[] colors = m_texture.GetPixels(0, 0, width, height);
+
+                texture.SetPixels(0, 0, width, height, colors);
+
+                texture.Apply();
+            }
+
+            m_texture = texture;
 
             MaterialTexture = m_texture;
         }


### PR DESCRIPTION
This commit adds sorting feature similar to what SpriteRenderer has. It
also polishes a few things, such as adding popups when data loss is
about to happen, adding warnings when not having tiles selected etc.
Major thing is keeping the old data when changing the layer size. When
creating mesh, the edit mode is automatically turned on, so that user
can see his change. Also deleting the mesh turns it off. Added a new
Clear button that removes all the tiles user has set.
Position of the mesh is now synced with the position of the TileMapBehaviour's GO when user selects it.
This guarantees sync with the grid, which was not moving with the GO at all before (this was also fixed).